### PR TITLE
Build Linux and Mac wheels on GitHub Actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,48 @@
+name: Build Wheels
+
+on: [push, pull_request]
+
+env:
+  # Don't build python 2.7, pypy, or 32-bit Linux wheels
+  CIBW_SKIP: "cp27-* pp* *-manylinux_i686"
+
+  # Run this script before each build...
+  CIBW_BEFORE_BUILD: . ./scripts/github-actions/before_cibuildwheel.sh
+
+  # This has some of the software we need pre-installed on it
+  CIBW_MANYLINUX_X86_64_IMAGE: hydroframebot/parflowio_manylinux2010_x86_64
+
+# Use bash by default for the run command
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install dependencies
+        run: . ./scripts/github-actions/install.sh
+
+      - name: Build
+        run: . ./scripts/github-actions/build.sh
+
+      - name: Build wheels
+        run:  python -m cibuildwheel --output-dir wheelhouse build/python/parflowio
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/scripts/github-actions/before_cibuildwheel.sh
+++ b/scripts/github-actions/before_cibuildwheel.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -ev
+
+# We must install numpy for each wheel...
+pip install numpy==1.18.5

--- a/scripts/github-actions/build.sh
+++ b/scripts/github-actions/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -ev
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  # Target deployment for OS X 10.9
+  export MACOSX_DEPLOYMENT_TARGET=10.9
+fi
+
+if [[ "$(uname)" == "Linux" ]]; then
+  # We must build using an older toolchain. Use docker to accomplish this.
+  docker run --entrypoint=bash --rm -v $PWD:/project $CIBW_MANYLINUX_X86_64_IMAGE -c 'export PATH=/opt/python/cp37-cp37m/bin:$PATH && pip install numpy==1.18.5 && mkdir -p /project/build && cd /project/build && cmake .. -DPACKAGE_TESTS=OFF -DBUILD_PYTHON=ON && make'
+else
+  # Mac and Windows...
+  mkdir -p build
+  cd build
+  # Set the python executable so it won't assume we are looking
+  # for Python 2.
+  cmake \
+    -DPACKAGE_TESTS=OFF \
+    -DBUILD_PYTHON=ON \
+    -DPython_EXECUTABLE=$(which python) \
+    ..
+    cmake --build .
+fi

--- a/scripts/github-actions/docker/Dockerfile
+++ b/scripts/github-actions/docker/Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=quay.io/pypa/manylinux2010_x86_64
+FROM ${BASE_IMAGE}
+
+RUN yum install -y \
+  wget \
+  pcre-devel
+
+# Build and install the latest cmake
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.sh && \
+  bash cmake-3.18.2-Linux-x86_64.sh --skip-license --prefix=/usr/local && \
+  rm cmake-3.18.2-Linux-x86_64.sh
+
+# Build and install swig
+RUN wget -q https://github.com/swig/swig/archive/v3.0.12.tar.gz && \
+  tar -xzf v3.0.12.tar.gz && \
+  rm v3.0.12.tar.gz && \
+  cd swig-3.0.12 && \
+  ./autogen.sh && \
+  ./configure && \
+  make -j5 && \
+  make install && \
+  cd .. && \
+  rm -r swig-3.0.12

--- a/scripts/github-actions/docker/build_and_push.sh
+++ b/scripts/github-actions/docker/build_and_push.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+image_base=quay.io/pypa/manylinux2010_x86_64
+tag=hydroframebot/parflowio_manylinux2010_x86_64
+
+docker build . -t $tag --build-arg BASE_IMAGE=$image_base
+docker push $tag

--- a/scripts/github-actions/install.sh
+++ b/scripts/github-actions/install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ev
+
+pip install cibuildwheel==1.5.5
+
+if [[ $RUNNER_OS == "Windows" ]]; then
+  choco install -y swig --version=3.0.12
+  pip install wheel numpy==1.18.5
+elif [[ $RUNNER_OS == "macOS" ]]; then
+  brew install swig
+  pip install wheel numpy==1.18.5
+fi


### PR DESCRIPTION
This utilizes [cibuildwheel](https://github.com/joerick/cibuildwheel) and GitHub Actions to build Linux and Mac wheels
for CPython 3.5 - 3.8, 64-bit.

The output wheels are uploaded as an artifact which can be downloaded and tested.

Windows will likely be needed at some point as well, and can be added.

It should also be an easy step to get GitHub actions to automatically upload the wheels
to PyPI.