### PR TITLE
Upload wheels to PyPI for tags that start with "v"

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,3 +46,20 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+
+  upload_pypi:
+    needs: build_wheels
+    name: Upload wheels to PyPI
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.hydroframebot_pypi_token }}


### PR DESCRIPTION
This should automatically upload wheels to PyPI when a tag is pushed
that starts with "v". For instance, "v0.0.2".

Note that the version number in the setup.py must be modified as well,
or PyPI will reject the wheels (because they will have the same name
as previous wheels).

We must also create a GitHub secret, "hydroframebot_pypi_token", that
contains a token that will be used to upload to PyPI, before this can
be merged.