### PR TITLE
Build wheels on Windows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,11 +3,11 @@ name: Build Wheels
 on: [push, pull_request]
 
 env:
-  # Don't build python 2.7, pypy, or 32-bit Linux wheels
-  CIBW_SKIP: "cp27-* pp* *-manylinux_i686"
+  # Don't build python 2.7, pypy, or 32-bit wheels
+  CIBW_SKIP: "cp27-* pp* *-manylinux_i686 *-win32"
 
   # Run this script before each build...
-  CIBW_BEFORE_BUILD: . ./scripts/github-actions/before_cibuildwheel.sh
+  CIBW_BEFORE_BUILD: bash ./scripts/github-actions/before_cibuildwheel.sh
 
   # This has some of the software we need pre-installed on it
   CIBW_MANYLINUX_X86_64_IMAGE: hydroframebot/parflowio_manylinux2010_x86_64

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,12 +22,7 @@ if(BUILD_PYTHON)
 
     message(STATUS "Finding Python (Interpreter)")
     # Find Python
-    find_package(Python REQUIRED COMPONENTS Interpreter)
-    message(STATUS "Found Python (Interpreter). Finding Development.Module.")
-    find_package(Python REQUIRED COMPONENTS Development.Module)
-    message(STATUS "Found Development.Module. Finding Numpy")
-    find_package(Python REQUIRED COMPONENTS NumPy)
-    message(STATUS "Found Numpy")
+    find_package(Python REQUIRED COMPONENTS Interpreter Development.Module NumPy)
 
     if(Python_VERSION VERSION_GREATER_EQUAL 3)
       list(APPEND CMAKE_SWIG_FLAGS "-py3;-DPY3")

--- a/scripts/github-actions/before_cibuildwheel.sh
+++ b/scripts/github-actions/before_cibuildwheel.sh
@@ -3,3 +3,17 @@ set -ev
 
 # We must install numpy for each wheel...
 pip install numpy==1.18.5
+
+if [[ "$(uname)" != "Linux" ]] && [[ "$(uname)" != "Darwin" ]]; then
+  # Windows links to the python libraries, so we need to re-build
+  # each time with the current version of python.
+  rm -rf build
+  mkdir -p build
+  cd build
+  cmake \
+    -DPACKAGE_TESTS=OFF \
+    -DBUILD_PYTHON=ON \
+    -DPython_EXECUTABLE=$(which python) \
+    ..
+  cmake --build . --config Release
+fi

--- a/scripts/github-actions/build.sh
+++ b/scripts/github-actions/build.sh
@@ -13,12 +13,10 @@ else
   # Mac and Windows...
   mkdir -p build
   cd build
-  # Set the python executable so it won't assume we are looking
-  # for Python 2.
   cmake \
     -DPACKAGE_TESTS=OFF \
     -DBUILD_PYTHON=ON \
     -DPython_EXECUTABLE=$(which python) \
     ..
-    cmake --build .
+  cmake --build . --config Release
 fi


### PR DESCRIPTION
This builds 64-bit wheels on Windows.

A few changes were made to do so:

1. All python components are found at once, so that all components have the same python version.
2. parflowio is re-built for each python version on Windows since it links to the python libraries.

I performed a basic test with all four of the Windows wheels (python 3.5 - 3.8), and they seemed to work.