### PR TITLE
Fixed memory leak. Deprecated python method getDataAsArray(). Replace…

### DIFF
--- a/include/parflow/pfdata.hpp
+++ b/include/parflow/pfdata.hpp
@@ -1,10 +1,9 @@
 #ifndef PARFLOWIO_PFDATA_HPP
 #define PARFLOWIO_PFDATA_HPP
 #include <array>
-#include <cstddef>
 #include <cstdio>
-#include <vector>
 #include <string>
+#include <vector>
 
 /**
  * class: PFData
@@ -14,16 +13,32 @@
 class PFData {
 private:
     std::string m_filename;
-    FILE* m_fp;
+    std::FILE* m_fp = nullptr;
 
     // The following information is available only after the file is opened
     // main header information
-    double m_X,m_Y,m_Z;
-    int m_nx,m_ny,m_nz;
-    double m_dX,m_dY,m_dZ;
-    int m_numSubgrids;
-    int m_p,m_q,m_r;
-    double* m_data;
+    double m_X = 0.0;
+    double m_Y = 0.0;
+    double m_Z = 0.0;
+
+    int m_nx = 0;
+    int m_ny = 0;
+    int m_nz = 0;
+
+    double m_dX = 1.0;
+    double m_dY = 1.0;
+    double m_dZ = 1.0;
+
+    int m_numSubgrids{};
+    int m_p = 1;
+    int m_q = 1;
+    int m_r = 1;
+
+    //Tracks if we own m_data, and need to free it.
+    bool m_dataOwner = false;
+
+    double* m_data = nullptr;
+
 	/**
 	 * writeFile
 	 * @param string filename
@@ -37,7 +52,7 @@ public:
      * PFData
      * Default constructor, useful when storing data that may be written later
      */
-    PFData();
+    PFData() = default;
 
     /**
      * PFData
@@ -57,6 +72,9 @@ public:
      */
     PFData(double * data, int nz, int ny, int nx);
 
+    //Closes the file descriptor, if open. If we own the backing data memory, it is freed.
+    ~PFData();
+
     /**
      * loadHeader
      * @retval 0 on success, non 0 on failure (sets errno)
@@ -71,19 +89,14 @@ public:
      * This function reads all of the data from the pfb file into memory.
      */
      int loadData();
+
 	 /**
 	  * writeFile
 	  * @param string filenamee
 	  * @return int
 	  */
      int writeFile(std::string filename);
-	 /**
-	  * writeFile
-	  * @param empty
-	  * @reutrn int
-	  */
 
-     int writeFile();
 	 /**
 	  * distFile
 	  * @param int P
@@ -401,6 +414,11 @@ public:
 	 * @return empty
 	 */
     void close();
+
+    /**Sets if the class owns the backing data or not. Mostly provided for compatibility with SWIG.
+     * \param   isOwner     True if the class should free the data upon destruction, false otherwise.
+     */
+    void setIsDataOwner(bool isOwner);
 
 
 };

--- a/python/parflowio.i
+++ b/python/parflowio.i
@@ -32,46 +32,83 @@ PFData::differenceType PFData::compare(const PFData& otherObj, std::array<int, 3
 //Ignore this constructor, and replace it with our own down below
 %ignore PFData::PFData(double* data, int nz, int ny, int nx);
 
+//Ignore these functions
+%ignore PFData::getData();
+%ignore PFData::getData() const;
+%ignore PFData::setData(double*);
+
 %include "parflow/pfdata.hpp"
 
 %extend PFData {
-    
+    #include <cstdlib>
+    #include <cstring>
+
     #include "Python.h"
     #include "numpy/arrayobject.h"
 
-    PyObject * getDataAsArray(){        
-        npy_intp dims[3] = {0};
-        dims[0]=$self->getNZ();
-        dims[1]=$self->getNY();
-        dims[2]=$self->getNX();
-        return PyArray_SimpleNewFromData(3, dims, NPY_DOUBLE, static_cast<void*>($self->getData()));
+    PFData(PyObject* pyObj){
+        PyArrayObject* pyArray = reinterpret_cast<PyArrayObject*>(PyArray_FromAny(pyObj, PyArray_DescrFromType(NPY_DOUBLE), 3, 3, NPY_ARRAY_INOUT_ARRAY, nullptr));
+
+        npy_intp* arr_shape = PyArray_SHAPE(pyArray);
+
+        npy_intp ind[3] = {0,0,0};
+        return new PFData(static_cast<double*>(PyArray_GetPtr(pyArray, ind)), arr_shape[0], arr_shape[1], arr_shape[2]);
     }
 
     void setDataArray(PyObject * pyObjIn){
-        PyArrayObject *pyArrayIn;
-        pyArrayIn = (PyArrayObject *) PyArray_FromAny(pyObjIn,PyArray_DescrFromType(NPY_DOUBLE),3,3,NPY_ARRAY_INOUT_ARRAY, nullptr);
+        PyArrayObject* pyArrayIn = reinterpret_cast<PyArrayObject*>(PyArray_FromAny(pyObjIn, PyArray_DescrFromType(NPY_DOUBLE), 3, 3, NPY_ARRAY_INOUT_ARRAY, nullptr));
+
         npy_intp ind[3] = {0,0,0};
-        $self->setData((double *) PyArray_GetPtr(pyArrayIn, ind));
-        npy_intp * arr_shape = PyArray_SHAPE(pyArrayIn);
+        $self->setData(static_cast<double*>(PyArray_GetPtr(pyArrayIn, ind)));
+        $self->setIsDataOwner(false);
+
+        npy_intp* arr_shape = PyArray_SHAPE(pyArrayIn);
         $self->setNZ(arr_shape[0]);
         $self->setNY(arr_shape[1]);
         $self->setNX(arr_shape[2]);
-
     }
 
-    PFData(PyObject* pyObj){
-        PFData* data = new PFData();
-        PyArrayObject* pyArray = (PyArrayObject*) PyArray_FromAny(pyObj, PyArray_DescrFromType(NPY_DOUBLE), 3, 3, NPY_ARRAY_INOUT_ARRAY, nullptr);
+    PyObject* moveDataArray(){
+        double* data = $self->getData();
+        if(!data) return Py_None;
 
-        npy_intp ind[3] = {0,0,0};
-        data->setData((double*) PyArray_GetPtr(pyArray, ind));
-        npy_intp* arr_shape = PyArray_SHAPE(pyArray);
-        data->setNZ(arr_shape[0]);
-        data->setNY(arr_shape[1]);
-        data->setNX(arr_shape[2]);
+        $self->setData(nullptr);
+        $self->setIsDataOwner(false);
 
-        return data;
+        npy_intp strides[3] = {$self->getNZ(), $self->getNY(), $self->getNX()};
+
+        PyObject* pyarray = PyArray_SimpleNewFromData(3, strides, NPY_DOUBLE, data);
+        PyArray_ENABLEFLAGS(reinterpret_cast<PyArrayObject*>(pyarray), NPY_ARRAY_OWNDATA);
+        return pyarray;
     }
+
+    PyObject* copyDataArray(){
+        double* data = $self->getData();
+        if(!data) return Py_None;
+
+        const int size = $self->getNZ() * $self->getNY() * $self->getNX();
+        double* dataCopy = static_cast<double*>(std::malloc(size * sizeof(double)));
+        memcpy(dataCopy, data, size*sizeof(double));    //Note: #include <cstring> doesnt bring in std::memcpy, but does bring in memcpy. ????
+
+        npy_intp strides[3] = {$self->getNZ(), $self->getNY(), $self->getNX()};
+        PyObject* pyarray = PyArray_SimpleNewFromData(3, strides, NPY_DOUBLE, dataCopy);
+        PyArray_ENABLEFLAGS(reinterpret_cast<PyArrayObject*>(pyarray), NPY_ARRAY_OWNDATA);
+        return pyarray;
+    }
+
+    PyObject* viewDataArray(){
+        double* data = $self->getData();
+        if(!data) return Py_None;
+
+        npy_intp strides[3] = {$self->getNZ(), $self->getNY(), $self->getNX()};
+        return PyArray_SimpleNewFromData(3, strides, NPY_DOUBLE, data);
+    }
+
+    //DEPRECATED: WILL BE REMOVED SOON
+    PyObject* getDataAsArray(){
+        return PFData_viewDataArray($self);
+    }
+
 
     %pythoncode %{
     def __str__(self):
@@ -82,3 +119,4 @@ PFData::differenceType PFData::compare(const PFData& otherObj, std::array<int, 3
     %}
 
 };
+

--- a/python/test.py
+++ b/python/test.py
@@ -74,7 +74,7 @@ class PFDataClassTests(unittest.TestCase):
         self.assertEqual(0, retval, 'should load header of file that exists')
         retval = test.loadData()
         self.assertEqual(0, retval, 'should load data from valid file')
-        data = test.getDataAsArray()
+        data = test.viewDataArray()
         self.assertIsNotNone(data, 'data from object should be available as python object')
         self.assertSequenceEqual((50, 41, 41), data.shape)
         self.assertAlmostEqual(98.003604098773, test(0, 0, 0), 12, 'valid data in cell (0,0,0)')
@@ -108,7 +108,7 @@ class PFDataClassTests(unittest.TestCase):
         self.assertEqual(PFData.differenceType_x, test1.compare(test2)[0], "The x values differ")
         test1.setX(test1.getX()-1.0)
 
-        arr = test1.getDataAsArray()
+        arr = test1.viewDataArray()
         arr[1][2][3] += 1.0
         ret, zyx = test1.compare(test2)
         self.assertEqual(PFData.differenceType_data, ret, "The data values differ")
@@ -130,8 +130,8 @@ class PFDataClassTests(unittest.TestCase):
         data2 = PFData(('press.init.pfb.tmp'))
         data2.loadHeader()
         data2.loadData()
-        self.assertIsNone(np.testing.assert_array_equal(test.getDataAsArray(),
-                                                        data2.getDataAsArray(),
+        self.assertIsNone(np.testing.assert_array_equal(test.viewDataArray(),
+                                                        data2.viewDataArray(),
                                                         'should read back same values we wrote'))
         in_file_hash = calculate_sha1_hash(('press.init.pfb'))
         out_file_hash = calculate_sha1_hash(('press.init.pfb.tmp'))
@@ -156,7 +156,7 @@ class PFDataClassTests(unittest.TestCase):
         self.assertEqual(0, retval, 'should load header of file that exists')
         retval = test.loadData()
         self.assertEqual(0, retval, 'should load data from valid file')
-        test_data = test.getDataAsArray()
+        test_data = test.viewDataArray()
         self.assertSequenceEqual((50, 41, 41), test_data.shape, 'test file array should have shape (50,41,41)')
         self.assertAlmostEqual(98.003604098773, test(0, 0, 0), 12, 'valid data in cell (0,0,0)')
         test_data[0, 0, 0] = 1
@@ -188,7 +188,7 @@ class PFDataClassTests(unittest.TestCase):
                                                                                         672608])]
         self.assertEqual(0, out_file.loadHeader(), 'should load distributed file header')
         self.assertEqual(0, out_file.loadData(), 'should load distributed data')
-        self.assertIsNone(np.testing.assert_array_equal(test.getDataAsArray(), out_file.getDataAsArray()),
+        self.assertIsNone(np.testing.assert_array_equal(test.viewDataArray(), out_file.viewDataArray()),
                           'should find matching data values in original and distributed files')
         test.close()
         out_file.close()
@@ -207,7 +207,7 @@ class PFDataClassTests(unittest.TestCase):
                                                                                          322960])]
         self.assertEqual(0, out_file.loadHeader(), 'should load distributed file header')
         self.assertEqual(0, out_file.loadData(), 'should load distributed data')
-        self.assertIsNone(np.testing.assert_array_equal(test.getDataAsArray(), out_file.getDataAsArray()),
+        self.assertIsNone(np.testing.assert_array_equal(test.viewDataArray(), out_file.viewDataArray()),
                           'should find matching data values in original and distributed files')
         test.close()
         out_file.close()
@@ -244,7 +244,7 @@ class PFDataClassTests(unittest.TestCase):
         self.assertEqual(1, test_read.getP())
         self.assertEqual(1, test_read.getQ())
         self.assertEqual(1, test_read.getR())
-        test_data = test_read.getDataAsArray()
+        test_data = test_read.viewDataArray()
         self.assertIsNone(np.testing.assert_array_equal(data, test_data), 'Data written to array should exist in '
                                                                           'written PFB file.')
         del data
@@ -277,7 +277,7 @@ class PFDataClassTests(unittest.TestCase):
         self.assertEqual(1, test_read.getP())
         self.assertEqual(1, test_read.getQ())
         self.assertEqual(1, test_read.getR())
-        test_data = test_read.getDataAsArray()
+        test_data = test_read.viewDataArray()
         self.assertIsNone(np.testing.assert_array_equal(data, test_data), 'Data written to array should exist in '
                                                                           'written PFB file.')
         del data
@@ -285,6 +285,24 @@ class PFDataClassTests(unittest.TestCase):
         test_read.close()
         os.remove(('test_write_raw.pfb'))
 
+    def test_view(self):
+        data = np.random.random_sample((50, 49, 31))
+        test = PFData(data)
+        view = test.viewDataArray()
+        self.assertTrue(np.array_equal(data, view), 'Data obtained from PFData::viewDataArray must match given data')
+
+    def test_copy(self):
+        data = np.random.random_sample((50, 49, 31))
+        test = PFData(data)
+        copy = test.copyDataArray()
+        self.assertTrue(np.array_equal(data, copy), 'Data obtained from PFData::copyDataArray must match given data')
+
+    def test_move(self):
+        data = np.random.random_sample((50, 49, 31))
+        test = PFData(data)
+        move = test.moveDataArray()
+        self.assertTrue(np.array_equal(data, move), 'Data obtained from PFData::moveDataArray must match given data')
+        self.assertIsNone(test.viewDataArray(), 'Calling PFData::moveDataArray must invalidate the internal data pointer')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…d with viewDataArray(), copyDataArray(), and moveDataArray() to provide ownership semantics

There are now three ways to access the data from Python:
1. `viewDataArray()`: Returns a `numpy` array that **does not own** the underlying data, nor does it extend its lifetime. Only valid as long as the `PFData` object it was created from is valid. This was the behavior of `getDataAsArray`(), and is the direct replacement for it.

2. `copyDataArray()`: Returns a `numpy` array that **contains a copy** of the underlying data, and **owns this copy**. This array is valid for as long as the array can be legally accessed. (i.e. it behaves exactly as you would expect a Python object to behave).

3. `moveDataArray()`: Returns a `numpy` array that **does own** the underlying data. This transfers ownership of the data from the C++ code to the Python code. The C++ pointer to the data is set to `nullptr`, and is not freed upon the `PFData`'s destruction. Use this if you need the array to outlive the `PFData` object and don't want to copy it. This array is valid for as long as the array can be legally accessed. (i.e. it behaves exactly as you would expect a Python object to behave). **After calling this method, it is not legal to call any methods on the `PFData` object that would access the data, without re-loading the data.**

This isn't new, but a note: If a `PFData` object is constructed from a `numpy` array, that array must live for at least as long as the `PFData` object does. (Constructing a `PFData` object from a `numpy` array does not currently increment the array reference count.)

Fixed some uninitialized members in `PFData`.
The methods `getData` and `setData` are now hidden from the Python interface.
Added `~PFData()`. If it owns the memory, frees it, and also closes the file handle if it is open.