### PR TITLE
Bump python dependency versions

### DIFF
--- a/scripts/github-actions/before_cibuildwheel.sh
+++ b/scripts/github-actions/before_cibuildwheel.sh
@@ -2,7 +2,7 @@
 set -ev
 
 # We must install numpy for each wheel...
-pip install numpy==1.18.5
+pip install numpy==1.19.4
 
 if [[ "$(uname)" != "Linux" ]] && [[ "$(uname)" != "Darwin" ]]; then
   # Windows links to the python libraries, so we need to re-build

--- a/scripts/github-actions/build.sh
+++ b/scripts/github-actions/build.sh
@@ -8,7 +8,7 @@ fi
 
 if [[ "$(uname)" == "Linux" ]]; then
   # We must build using an older toolchain. Use docker to accomplish this.
-  docker run --entrypoint=bash --rm -v $PWD:/project $CIBW_MANYLINUX_X86_64_IMAGE -c 'export PATH=/opt/python/cp37-cp37m/bin:$PATH && pip install numpy==1.18.5 && mkdir -p /project/build && cd /project/build && cmake .. -DPACKAGE_TESTS=OFF -DBUILD_PYTHON=ON && make'
+  docker run --entrypoint=bash --rm -v $PWD:/project $CIBW_MANYLINUX_X86_64_IMAGE -c 'export PATH=/opt/python/cp37-cp37m/bin:$PATH && pip install numpy==1.19.4 && mkdir -p /project/build && cd /project/build && cmake .. -DPACKAGE_TESTS=OFF -DBUILD_PYTHON=ON && make'
 else
   # Mac and Windows...
   mkdir -p build

--- a/scripts/github-actions/install.sh
+++ b/scripts/github-actions/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -ev
 
-pip install cibuildwheel==1.5.5
+pip install cibuildwheel==1.6.4
 
 if [[ $RUNNER_OS == "Windows" ]]; then
   choco install -y swig --version=3.0.12
-  pip install wheel numpy==1.18.5
+  pip install wheel numpy==1.19.4
 elif [[ $RUNNER_OS == "macOS" ]]; then
   brew install swig
-  pip install wheel numpy==1.18.5
+  pip install wheel numpy==1.19.4
 fi


### PR DESCRIPTION
cibuildwheel: 1.5.5 => 1.6.4
numpy: 1.18.5 => 1.19.4

cibuildwheel >= 1.6.0 is needed to build python 3.9 wheels.