### PR TITLE
Index order attribute

### DIFF
--- a/include/parflow/pfdata.hpp
+++ b/include/parflow/pfdata.hpp
@@ -35,6 +35,9 @@ private:
     int m_q = 1;
     int m_p = 1;
 
+    // Indicates indexing order of numpy arrays
+    std::string m_indexOrder = "zyx";
+
     //Tracks if we own m_data, and need to free it.
     bool m_dataOwner = false;
 
@@ -554,6 +557,18 @@ public:
 	 * @param int grid
 	 */
     double* getSubgridData(int grid);
+
+    /**
+    * getIndexOrder
+    * @return string
+    */
+    std::string getIndexOrder() const;
+
+    /**
+    * setIndexOrder
+    * @param string indexOrder
+    */
+    void setIndexOrder(std::string indexOrder);
 
     /**
      * getData

--- a/python/parflowio.i
+++ b/python/parflowio.i
@@ -106,9 +106,9 @@ PFData::differenceType PFData::compare(const PFData& otherObj, std::array<int, 3
 
     %pythoncode %{
     def __str__(self):
-        s = str(self.__class__.__name__) + "(X={}, Y={}, Z={}, NX={}, NY={}, NZ={}, DX={}, DY={}, DZ={})".format(self
-                .getX(), self.getY(), self.getZ(), self.getNX(), self.getNY(), self.getNZ(), self.getDX(), self.getDY(),
-                self.getDZ())
+        s = str(self.__class__.__name__) + "(X={}, Y={}, Z={}, NX={}, NY={}, NZ={}, DX={}, DY={}, DZ={}, indexOrder={})".format(
+                self.getX(), self.getY(), self.getZ(), self.getNX(), self.getNY(), self.getNZ(), self.getDX(),
+                self.getDY(), self.getDZ(), self.getIndexOrder())
         return s
     %}
 

--- a/python/test.py
+++ b/python/test.py
@@ -177,12 +177,61 @@ class PFDataClassTests(unittest.TestCase):
         test.close()
 
         # loadDataThreaded() should have less total time spent than loadData()
-        assert threaded_time < non_threaded_time, f'Using {num_threads} threads has degraded the performance of loadDataThreaded()'
+        self.assertTrue(threaded_time < non_threaded_time, f'Using {num_threads} threads has degraded the performance of loadDataThreaded()')
 
         # Display performance increase in percent change
         pct_change = 100 * abs(threaded_time - non_threaded_time) / non_threaded_time
         print(f'{pct_change:.2f}% performance increase when using LoadDataThreaded() with {num_threads} threads')
 
+    def test_set_index_order(self):
+        test = PFData(('press.init.pfb'))
+
+        self.assertEqual(test.getIndexOrder(), 'zyx', 'indexOrder should equal \'zyx\'')
+
+        test.setIndexOrder('xyz')
+        self.assertEqual(test.getIndexOrder(), 'xyz', 'indexOrder should equal \'xyz\'')
+
+        test.setIndexOrder('xYz')
+        self.assertEqual(test.getIndexOrder(), 'xyz', 'indexOrder should equal \'xyz\'')
+
+        test.setIndexOrder('xYZ')
+        self.assertEqual(test.getIndexOrder(), 'xyz', 'indexOrder should equal \'xyz\'')
+
+        test.setIndexOrder('XYZ')
+        self.assertEqual(test.getIndexOrder(), 'xyz', 'indexOrder should equal \'xyz\'')
+
+        test.setIndexOrder('XYZZZZ')
+        self.assertEqual(test.getIndexOrder(), 'xyz', 'indexOrder should equal \'xyz\'')
+
+        # Should not work, should still equal 'xyz'
+        test.setIndexOrder('abc')
+        self.assertEqual(test.getIndexOrder(), 'xyz', 'indexOrder should equal \'xyz\'')
+
+        # Should not be able to write to file when indexOrder == 'xyz'
+        self.assertEqual(test.writeFile(('test_write_index_order.pfb')), 1,
+                         'Should not be able to write to file when indexOrder == \'xyz\'')
+
+        # Should equal 'zyx'
+        test.setIndexOrder('ZYX')
+        self.assertEqual(test.getIndexOrder(), 'zyx', 'indexOrder should equal \'zyx\'')
+
+        # Should equal 'zyx'
+        test.setIndexOrder('zYx')
+        self.assertEqual(test.getIndexOrder(), 'zyx', 'indexOrder should equal \'zyx\'')
+
+        # Should be able to write to file
+        self.assertEqual(test.writeFile(('test_write_index_order.pfb')), 0,
+                         'Should be able to write to file when indexOrder == \'zyx\'')
+
+        # Read file, indexOrder should equal 'zyx'
+        test_read = PFData(('test_write_index_order.pfb'))
+        test_read.loadHeader()
+        test_read.loadData()
+        self.assertEqual(test.getIndexOrder(), 'zyx', 'indexOrder should equal \'zyx\'')
+
+        test.close()
+        test_read.close()
+        os.remove(('test_write_index_order.pfb'))
 
     def test_read_write_data(self):
         test = PFData(('press.init.pfb'))

--- a/src/pfdata.cpp
+++ b/src/pfdata.cpp
@@ -546,6 +546,27 @@ double PFData::operator()(int z, int y, int x) {
     return m_data[z*m_ny*m_nx+y*m_nx+x];
 }
 
+std::string PFData::getIndexOrder() const {
+    return m_indexOrder;
+}
+
+void PFData::setIndexOrder(std::string indexOrder) {
+    // Input string should only be 3 chars long - "zyx" or "xyz"
+    indexOrder = indexOrder.substr(0, 3);
+
+    // Convert string to lowercase and compare to valid indexOrder strings
+    for (int i = 0; i < (int)indexOrder.length(); i++) {
+        indexOrder[i] = std::tolower(indexOrder[i]);
+
+        if ((indexOrder[i] != "zyx"[i]) && (indexOrder[i] != "xyz"[i])) {
+            return;
+        }
+    }
+
+    // At this point, indexOrder is valid
+    m_indexOrder = indexOrder;
+}
+
 double* PFData::getData() {
     return m_data;
 }
@@ -723,8 +744,6 @@ int PFData::loadDataThreaded(const int numThreads){
         pool.at(i) = std::thread(threadFunc, subgridBegin, subgridEnd, fps.at(i), std::ref(retCodes.at(i)));
     }
 
-
-
     for(int i = 0; i < numThreads; ++i){
         pool.at(i).join();
         std::fclose(fps.at(i));
@@ -749,13 +768,20 @@ void PFData::close() {
     }
 }
 
-
 int PFData::writeFile(const std::string filename) {
     std::vector<long> _offsets((m_p*m_q*m_r) + 1);
     return writeFile(filename, _offsets);
 }
 
 int PFData::writeFile(const std::string filename, std::vector<long> &byte_offsets) {
+    // m_indexOrder must be set to "zyx" in order to write file
+    // Notify user and exit function if not
+    if (m_indexOrder != "zyx") {
+        perror("PFData indexOrder attribute must be set to \"zyx\" before calling writeFile(). "
+                "Please confirm that your arrays are in the right order, and call setIndexOrder() "
+                "on your PFData object to set this attribute.");
+        return 1;
+    }
 
     std::FILE* fp = std::fopen(filename.c_str(), "wb");
     if(fp == nullptr){

--- a/tests/PFData_test.cpp
+++ b/tests/PFData_test.cpp
@@ -6,7 +6,6 @@
 #include <fstream>
 #include <string>
 #include <cstdlib>
-#include <cassert>
 
 class PFData_test : public ::testing::Test {
 

--- a/tests/PFData_test.cpp
+++ b/tests/PFData_test.cpp
@@ -6,9 +6,7 @@
 #include <fstream>
 #include <string>
 #include <cstdlib>
-
-
-
+#include <cassert>
 
 class PFData_test : public ::testing::Test {
 
@@ -405,53 +403,6 @@ TEST_F(PFData_test, loadDataAbs) {
     test.close();
 }
 
-//TEST_F(PFData_test, readWrite){
-//    char buf1[1024];
-//    char buf2[1024];
-//
-//    PFData test("tests/inputs/press.init.pfb");
-//    int retval = test.loadHeader();
-//    ASSERT_EQ(0,retval);
-//    retval = test.loadData();
-//    ASSERT_EQ(0,retval);
-//    retval = test.writeFile("tests/press.init.pfb.tmp");
-//    ASSERT_EQ(0,retval);
-//
-//    FILE* f1 = fopen("tests/inputs/press.init.pfb","rb");
-//    FILE* f2 = fopen("tests/press.init.pfb.tmp","rb");
-//    ASSERT_NE(f1,nullptr);
-//    ASSERT_NE(f2,nullptr);
-//    int retval1 = fread(buf1,1,1024,f1);
-//    int retval2 = fread(buf2,1,1024,f2);
-//    int diff = 0;
-//    int count = 0;
-//    EXPECT_EQ(retval1,retval2);
-//    while(retval1 == retval2 && retval1 == 1024){
-//        if(memcmp(buf1,buf2,1024) != 0){
-//            diff = 1;
-//            fprintf(stderr,"Files differ at  read %d\n",count);
-//            int tstCount=1;
-//            while(memcmp(buf1,buf2,tstCount)==0){tstCount++;}
-//            fprintf(stderr,"Files differ at  byte %d\n",tstCount);
-//            fprintf(stderr,"val0: %lf val1: %lf",(double)buf1[tstCount-1],(double)buf2[tstCount-1]);
-//
-//            break;
-//        }
-//        retval1 = fread(buf1,1,1024,f1);
-//        retval2 = fread(buf2,1,1024,f2);
-//        count++;
-//    }
-//    ASSERT_EQ(0,diff);
-//    ASSERT_EQ(retval1,retval2);
-//    if(memcmp(buf1,buf2,retval1) != 0){
-//        diff = 1;
-//    }
-//    ASSERT_EQ(0,diff);
-//    fclose(f1);
-//    fclose(f2);
-//    ASSERT_EQ(0,remove("tests/press.init.pfb.tmp"));
-//
-//}
 TEST_F(PFData_test, dist_press){
     char buf1[1024];
     char buf2[1024];
@@ -641,18 +592,62 @@ TEST_F(PFData_test, setData){
     ASSERT_EQ(0,remove("tests/test_write_file_out.pfb"));
 }
 
-//TEST_F(PFData_test, readFile){
-	//std::ofstream readFile("newFile");
-	//std::string  data="";
-	//std::string test="this will show up in the file.\n";
-	//
-	//readFile << test;
-	//readFile.close();
-	//std::ifstream infile;
-    //infile.open("newFile");
-	////infile.getline(data,100);
-	//while(!infile.eof()){
-			//infile >> data;}
-	////std::cout<<data<<std::endl;
-	//EXPECT_EQ(0,data.compare(test));
-//}
+TEST_F(PFData_test, setIndexOrder) {
+    PFData test = PFData();
+    double data[24];
+    for (int i =0; i<24; i++) {
+        data[i] = (double) rand() / 1000;
+    }
+    test.setData(data);
+
+    // Should equal "zyz"
+    EXPECT_EQ(test.getIndexOrder(), "zyx");
+
+    // Should equal "xyz"
+    test.setIndexOrder("xyz");
+    EXPECT_EQ(test.getIndexOrder(), "xyz");
+
+    // Should equal "xyz"
+    test.setIndexOrder("xYz");
+    EXPECT_EQ(test.getIndexOrder(), "xyz");
+
+    // Should equal "xyz"
+    test.setIndexOrder("xYZ");
+    EXPECT_EQ(test.getIndexOrder(), "xyz");
+
+    // Should equal "xyz"
+    test.setIndexOrder("XYZ");
+    EXPECT_EQ(test.getIndexOrder(), "xyz");
+
+    // Should equal "xyz"
+    test.setIndexOrder("XYZZZZ");
+    EXPECT_EQ(test.getIndexOrder(), "xyz");
+
+    // Should not work, should still equal "xyz"
+    test.setIndexOrder("abc");
+    EXPECT_EQ(test.getIndexOrder(), "xyz");
+
+    // Should not be able to write to file when indexOrder == "xyz"
+    ASSERT_EQ(test.writeFile("tests/test_write_index_order.pfb"), 1);
+
+    // Should equal "zyx"
+    test.setIndexOrder("ZYX");
+    EXPECT_EQ(test.getIndexOrder(), "zyx");
+
+    // Should equal "zyx"
+    test.setIndexOrder("zYx");
+    EXPECT_EQ(test.getIndexOrder(), "zyx");
+
+    // Should be able to write to file
+    ASSERT_EQ(test.writeFile("tests/test_write_index_order.pfb"), 0);
+
+    // Read file, indexOrder should equal "zyx"
+    PFData test_read = PFData("tests/test_write_index_order.pfb");
+    test_read.loadHeader();
+    test_read.loadData();
+    EXPECT_EQ("zyx", test_read.getIndexOrder());
+
+    test.close();
+    test_read.close();
+    ASSERT_EQ(0, remove("tests/test_write_index_order.pfb"));
+}


### PR DESCRIPTION
Added `indexOrder` attribute to `PFData` class. Defaults to `"zyx"`, accessible through `PFData::getIndexOrder()` function. User can set to be `"xyz"` using `PFData::setIndexOrder()` function. Added error check to `PFData::writeFile()` function to ensure data is in `"zyx"` order before writing. Also added Python and C++ tests for these functions.