### PR TITLE
Fix memory leak from destructor

### DIFF
--- a/src/pfdata.cpp
+++ b/src/pfdata.cpp
@@ -44,7 +44,8 @@ PFData::~PFData(){
     }
 
     if(m_dataOwner && m_data != nullptr){
-        //std::free(m_data);
+        std::free(m_data);
+        m_dataOwner = false;
     }
 }
 
@@ -676,7 +677,7 @@ int PFData::loadClipOfData(int clip_x, int clip_y, int extent_x, int extent_y) {
         return 2;
     }
 
-    // this is more space than needed -- but doing it here allows us to 
+    // this is more space than needed -- but doing it here allows us to
     // allocate and free only one space
     uint64_t* buf =(uint64_t*) malloc(sizeof(uint64_t)*m_nx);
     if(buf == nullptr){
@@ -707,12 +708,12 @@ int PFData::loadClipOfData(int clip_x, int clip_y, int extent_x, int extent_y) {
         if(!errcheck){perror("Error Reading Subgrid Header"); return 1;}
 
         // is this subgrid part of our clip?
-        int x_overlap = fminl(clip_x+extent_x, x+nx) - fmaxl(clip_x,x); 
-        int y_overlap = fminl(clip_y+extent_y, y+ny) - fmaxl(clip_y,y); 
+        int x_overlap = fminl(clip_x+extent_x, x+nx) - fmaxl(clip_x,x);
+        int y_overlap = fminl(clip_y+extent_y, y+ny) - fmaxl(clip_y,y);
         if(x_overlap > 0 && y_overlap >0){
           // some of the data is in here -- will read the whole subgrid, but
           // only save the overlap part. There is room to optimize this later.
-          
+
           // read values for subgrid
           // z will always be 0
           long long k,i,j;
@@ -728,7 +729,7 @@ int PFData::loadClipOfData(int clip_x, int clip_y, int extent_x, int extent_y) {
                   int cx = gx - clip_x;
                   int cy = gy - clip_y;
                   int cz = gz;
- 
+
                   // check to see if this pencil will be in our y-range - seek if not
                   // this only looks at the specific y point not a range of them
                   if(gy>=clip_y && gy<clip_y+extent_y){
@@ -751,7 +752,7 @@ int PFData::loadClipOfData(int clip_x, int clip_y, int extent_x, int extent_y) {
                         uint64_t tmp = buf[j];
                         tmp = bswap64(tmp);
                         m_data[index] = *(double*)(&tmp);
-                      } 
+                      }
                     }
                   }else{
                     // this y point is not of interest - so

--- a/tests/PFData_test.cpp
+++ b/tests/PFData_test.cpp
@@ -457,7 +457,7 @@ TEST_F(PFData_test, loadClipTestTemp){
     // this file needs to exist, and should load
     char filename[2048];
     getcwd(filename,2048);
-    strcat(filename,"/tests/inputs/NLDAS.Press.000001_to_000024_orig.pfb");
+    strcat(filename,"/tests/inputs/NLDAS.APCP.000001_to_000024.pfb");
     PFData test(filename);
     int retval = test.loadHeader();
     ASSERT_EQ(0,retval);
@@ -472,7 +472,7 @@ TEST_F(PFData_test, loadClipTestTemp){
     EXPECT_EQ(0, test.getZ());
     EXPECT_EQ(1059, test.getY());
     EXPECT_EQ(2805, test.getX());
-    retval = test.writeFile("tests/inputs/NLDAS.Press.000001_to_000024_clip.pfb");
+    retval = test.writeFile("tests/inputs/NLDAS.APCP.000001_to_000024_clip.pfb");
     double* data = test.getData();
     EXPECT_NE(nullptr, data);
     //EXPECT_NEAR(95.173603867758615, test(0, 1, 1), 1E-12);


### PR DESCRIPTION
:wave: Hi `parflowio` maintainers - I'm a new postdoc working with Laura Condon at the University of Arizona. I've been building an [xarray extension for reading pfb files](https://github.com/arbennett/pf-xarray/tree/feature/lazyloading) which builds on `parflowio`. When implementing the infrastructure for lazy loading I noticed there's a memory leak due to the destructor for the `PFData` class not freeing memory associated after calling `loadData`. This PR simply frees `m_data` and sets `m_dataOwner` to `false`.

I looked back through the commit history here and it seems this change was made intentionally, so if this isn't the right place to do this for some other reason, perhaps I could implement this behavior as `PFData.unloadData` or some similar function. I'm open to discussion on how this functionality actually gets implemented.